### PR TITLE
fix resolver resolveUriKey

### DIFF
--- a/src/NovaAssertions.php
+++ b/src/NovaAssertions.php
@@ -73,8 +73,8 @@ trait NovaAssertions
 
     public function resolveUriKey($class)
     {
-        if (strpos($class, '\\')) {
-            return app($class)->uriKey();
+        if (strpos($class, '\\') && class_exists($class)) {
+            return app($class, [ 'resource' => $class::$model ])->uriKey();
         }
 
         return $class;

--- a/src/NovaAssertions.php
+++ b/src/NovaAssertions.php
@@ -74,7 +74,7 @@ trait NovaAssertions
     public function resolveUriKey($class)
     {
         if (strpos($class, '\\') && class_exists($class)) {
-            return app($class, [ 'resource' => $class::$model ])->uriKey();
+            return app($class, [ 'resource' => app($class::$model) ])->uriKey();
         }
 
         return $class;


### PR DESCRIPTION
`app($class)->uriKey()` can't be resolved if you give a classpath to it, as all nova resources need a $resource on its constructor.

This PR allows you to use the nova classpath directly: `$this->novaEdit(\App\Nova\User::class, 1)`