### PR TITLE
update namespace of illuminate Assert

### DIFF
--- a/src/Assert/AssertActions.php
+++ b/src/Assert/AssertActions.php
@@ -5,7 +5,7 @@ namespace NovaTesting\Assert;
 use closure;
 use Illuminate\Support\Arr;
 use NovaTesting\NovaResponse;
-use Illuminate\Foundation\Testing\Assert as PHPUnit;
+use Illuminate\Testing\Assert as PHPUnit;
 
 trait AssertActions
 {

--- a/src/Assert/AssertCards.php
+++ b/src/Assert/AssertCards.php
@@ -4,7 +4,7 @@ namespace NovaTesting\Assert;
 
 use closure;
 use NovaTesting\NovaResponse;
-use Illuminate\Foundation\Testing\Assert as PHPUnit;
+use Illuminate\Testing\Assert as PHPUnit;
 
 trait AssertCards
 {

--- a/src/Assert/AssertFields.php
+++ b/src/Assert/AssertFields.php
@@ -4,7 +4,7 @@ namespace NovaTesting\Assert;
 
 use closure;
 use Illuminate\Support\Collection;
-use Illuminate\Foundation\Testing\Assert as PHPUnit;
+use Illuminate\Testing\Assert as PHPUnit;
 
 trait AssertFields
 {

--- a/src/Assert/AssertFilters.php
+++ b/src/Assert/AssertFilters.php
@@ -4,7 +4,7 @@ namespace NovaTesting\Assert;
 
 use closure;
 use NovaTesting\NovaResponse;
-use Illuminate\Foundation\Testing\Assert as PHPUnit;
+use Illuminate\Testing\Assert as PHPUnit;
 
 trait AssertFilters
 {

--- a/src/Assert/AssertLenses.php
+++ b/src/Assert/AssertLenses.php
@@ -4,7 +4,7 @@ namespace NovaTesting\Assert;
 
 use closure;
 use NovaTesting\NovaResponse;
-use Illuminate\Foundation\Testing\Assert as PHPUnit;
+use Illuminate\Testing\Assert as PHPUnit;
 
 trait AssertLenses
 {

--- a/src/Assert/AssertPolicies.php
+++ b/src/Assert/AssertPolicies.php
@@ -4,7 +4,7 @@ namespace NovaTesting\Assert;
 
 use Laravel\Nova\Nova;
 use Illuminate\Support\Arr;
-use Illuminate\Foundation\Testing\Assert as PHPUnit;
+use Illuminate\Testing\Assert as PHPUnit;
 
 trait AssertPolicies
 {

--- a/src/Assert/AssertRelations.php
+++ b/src/Assert/AssertRelations.php
@@ -6,7 +6,7 @@ use closure;
 use NovaTesting\NovaResponse;
 use Laravel\Nova\Fields\HasMany;
 use Laravel\Nova\Fields\BelongsTo;
-use Illuminate\Foundation\Testing\Assert as PHPUnit;
+use Illuminate\Testing\Assert as PHPUnit;
 
 trait AssertRelations
 {

--- a/src/Assert/AssertResources.php
+++ b/src/Assert/AssertResources.php
@@ -5,7 +5,7 @@ namespace NovaTesting\Assert;
 use closure;
 use Illuminate\Support\Arr;
 use NovaTesting\NovaResponse;
-use Illuminate\Foundation\Testing\Assert as PHPUnit;
+use Illuminate\Testing\Assert as PHPUnit;
 
 trait AssertResources
 {


### PR DESCRIPTION
Looks like the namespace for Illuminate\Foundation\Testing\Assert changed to Illuminate\Testing\Assert  in laravel 7.

This pull request replaces all instances of the old namespace with the new one. Should probably be a new major version since this most likely breaks backwards compatibility