### PR TITLE
bugfix create and edit requests did not work with assertFieldCount

### DIFF
--- a/src/Assert/AssertFields.php
+++ b/src/Assert/AssertFields.php
@@ -10,7 +10,7 @@ trait AssertFields
 {
     public function assertFieldCount($amount)
     {
-        $path = isset($this->original['resources']) ? 'resources.0.fields' : 'resource.fields';
+        $path = isset($this->original['resources']) ? 'resources.0.fields' : $this->getFieldsPath();
 
         $this->assertJsonCount($amount, $path);
 
@@ -146,5 +146,19 @@ trait AssertFields
         }
 
         return $this;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getFieldsPath()
+    {
+        if ( isset($this->original[ 'resources' ][ 0 ][ 'fields' ]) ) {
+            return 'resources.*.fields';
+        } elseif ( isset($this->original[ 'resource' ][ 'fields' ]) ) {
+            return 'resource.fields';
+        }
+
+        return 'fields';
     }
 }

--- a/src/Assert/AssertFields.php
+++ b/src/Assert/AssertFields.php
@@ -10,7 +10,7 @@ trait AssertFields
 {
     public function assertFieldCount($amount)
     {
-        $path = isset($this->original[ 'resources' ]) ? 'resources.0.fields' : $this->getFieldsPath();
+        $path = isset($this->original['resources']) ? 'resources.0.fields' : 'resource.fields';
 
         $this->assertJsonCount($amount, $path);
 
@@ -19,55 +19,65 @@ trait AssertFields
 
     public function assertFields(closure $callable)
     {
-        $fields = collect(json_decode(json_encode(data_get($this->original, $this->getFieldsPath(), []), true)));
+        if (isset($this->original['resources'][0]['fields'])) {
+            $path = 'resources.*.fields';
+        } elseif (isset($this->original['resource']['fields'])) {
+            $path = 'resource.fields';
+        } elseif (isset($this->original['fields'])) {
+            $path = 'fields';
+        }
 
-        PHPUnit::assertTrue($callable($fields));
+        $fields = collect(json_decode(json_encode(data_get($this->original, $path, []), true)));
+
+        $isCallingOk = $callable($fields) ? true : false;
+
+        PHPUnit::assertTrue($isCallingOk);
 
         return $this;
     }
 
-    public function assertFieldsInclude($attribute, $value = null)
+    public function assertFieldsInclude($attribute, $value=null)
     {
         return $this->fieldCheck($attribute, $value, 'assertJsonFragment');
     }
 
-    public function assertFieldsExclude($attribute, $value = null)
+    public function assertFieldsExclude($attribute, $value=null)
     {
         return $this->fieldCheck($attribute, $value, 'assertJsonMissing');
     }
 
-    protected function fieldCheck($attribute, $value = null, $method = null)
+    protected function fieldCheck($attribute, $value = null, $method)
     {
-        if ( $attribute instanceof Collection ) {
+        if ($attribute instanceof Collection) {
             $attribute = $attribute->toArray();
         }
 
-        if ( $value instanceof Collection ) {
+        if ($value instanceof Collection) {
             $value = $value->toArray();
         }
 
         // ->assertFieldsInclude('id')
-        if ( ! is_array($attribute) && is_null($value) ) {
+        if (!is_array($attribute) && is_null($value)) {
             return $this->assertFieldAttribute($attribute, $method);
         }
 
         // ->assertFieldsInclude('id', [1,2,3])
-        if ( ! is_array($attribute) && is_array($value) ) {
+        if (!is_array($attribute) && is_array($value)) {
             return $this->assertFieldManyValues($attribute, $value, $method);
         }
 
         // ->assertFieldsInclude('id', 1)
-        if ( ! is_array($attribute) && ! is_null($value) ) {
+        if (!is_array($attribute) && !is_null($value)) {
             return $this->assertFieldValue($attribute, $value, $method);
         }
 
         // ->assertFieldsInclude(['id', 'email'])
-        if ( is_array($attribute) && is_numeric(array_keys($attribute)[ 0 ]) ) {
+        if (is_array($attribute) && is_numeric(array_keys($attribute)[0])) {
             return $this->assertFieldKeys($attribute, $method);
         }
 
         // ->assertFieldsInclude(['id' => 1])
-        if ( is_array($attribute) ) {
+        if (is_array($attribute)) {
             return $this->assertFieldKeyValue($attribute, $method);
         }
 
@@ -80,12 +90,34 @@ trait AssertFields
             'attribute' => $attribute
         ]);
     }
+    public function assertFieldOptions($attribute, $options,$method)
+    {
+        $formattedOptions = collect($options)->map(function ($value, $label) {
+            return [
+                'label' => $label,
+                'value' => $value,
+            ];
+        })->values()->all();
+
+        return $this->$method([
+            'attribute' => $attribute,
+            'options' => $formattedOptions
+        ]);
+    }
+
+    public function assertFieldRequired($attribute, $required, $method)
+    {
+        return $this->$method([
+            'attribute' => $attribute,
+            'required' => $required
+        ]);
+    }
 
     public function assertFieldValue($attribute, $value, $method)
     {
         return $this->$method([
             'attribute' => $attribute,
-            'value'     => $value,
+            'value' => $value,
         ]);
     }
 
@@ -114,19 +146,5 @@ trait AssertFields
         }
 
         return $this;
-    }
-
-    /**
-     * @return string
-     */
-    protected function getFieldsPath()
-    {
-        if ( isset($this->original[ 'resources' ][ 0 ][ 'fields' ]) ) {
-            return 'resources.*.fields';
-        } elseif ( isset($this->original[ 'resource' ][ 'fields' ]) ) {
-            return 'resource.fields';
-        }
-
-        return 'fields';
     }
 }

--- a/src/Assert/AssertFields.php
+++ b/src/Assert/AssertFields.php
@@ -26,48 +26,48 @@ trait AssertFields
         return $this;
     }
 
-    public function assertFieldsInclude($attribute, $value=null)
+    public function assertFieldsInclude($attribute, $value = null)
     {
         return $this->fieldCheck($attribute, $value, 'assertJsonFragment');
     }
 
-    public function assertFieldsExclude($attribute, $value=null)
+    public function assertFieldsExclude($attribute, $value = null)
     {
         return $this->fieldCheck($attribute, $value, 'assertJsonMissing');
     }
 
-    protected function fieldCheck($attribute, $value = null, $method)
+    protected function fieldCheck($attribute, $value = null, $method = null)
     {
-        if ($attribute instanceof Collection) {
+        if ( $attribute instanceof Collection ) {
             $attribute = $attribute->toArray();
         }
 
-        if ($value instanceof Collection) {
+        if ( $value instanceof Collection ) {
             $value = $value->toArray();
         }
 
         // ->assertFieldsInclude('id')
-        if (!is_array($attribute) && is_null($value)) {
+        if ( ! is_array($attribute) && is_null($value) ) {
             return $this->assertFieldAttribute($attribute, $method);
         }
 
         // ->assertFieldsInclude('id', [1,2,3])
-        if (!is_array($attribute) && is_array($value)) {
+        if ( ! is_array($attribute) && is_array($value) ) {
             return $this->assertFieldManyValues($attribute, $value, $method);
         }
 
         // ->assertFieldsInclude('id', 1)
-        if (!is_array($attribute) && !is_null($value)) {
+        if ( ! is_array($attribute) && ! is_null($value) ) {
             return $this->assertFieldValue($attribute, $value, $method);
         }
 
         // ->assertFieldsInclude(['id', 'email'])
-        if (is_array($attribute) && is_numeric(array_keys($attribute)[0])) {
+        if ( is_array($attribute) && is_numeric(array_keys($attribute)[ 0 ]) ) {
             return $this->assertFieldKeys($attribute, $method);
         }
 
         // ->assertFieldsInclude(['id' => 1])
-        if (is_array($attribute)) {
+        if ( is_array($attribute) ) {
             return $this->assertFieldKeyValue($attribute, $method);
         }
 
@@ -85,7 +85,7 @@ trait AssertFields
     {
         return $this->$method([
             'attribute' => $attribute,
-            'value' => $value,
+            'value'     => $value,
         ]);
     }
 

--- a/src/Assert/AssertFields.php
+++ b/src/Assert/AssertFields.php
@@ -10,7 +10,7 @@ trait AssertFields
 {
     public function assertFieldCount($amount)
     {
-        $path = isset($this->original['resources']) ? 'resources.0.fields' : 'resource.fields';
+        $path = isset($this->original[ 'resources' ]) ? 'resources.0.fields' : $this->getFieldsPath();
 
         $this->assertJsonCount($amount, $path);
 
@@ -19,15 +19,7 @@ trait AssertFields
 
     public function assertFields(closure $callable)
     {
-        if (isset($this->original['resources'][0]['fields'])) {
-            $path = 'resources.*.fields';
-        } elseif (isset($this->original['resource']['fields'])) {
-            $path = 'resource.fields';
-        } elseif (isset($this->original['fields'])) {
-            $path = 'fields';
-        }
-
-        $fields = collect(json_decode(json_encode(data_get($this->original, $path, []), true)));
+        $fields = collect(json_decode(json_encode(data_get($this->original, $this->getFieldsPath(), []), true)));
 
         PHPUnit::assertTrue($callable($fields));
 
@@ -122,5 +114,19 @@ trait AssertFields
         }
 
         return $this;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getFieldsPath()
+    {
+        if ( isset($this->original[ 'resources' ][ 0 ][ 'fields' ]) ) {
+            return 'resources.*.fields';
+        } elseif ( isset($this->original[ 'resource' ][ 'fields' ]) ) {
+            return 'resource.fields';
+        }
+
+        return 'fields';
     }
 }

--- a/src/Assert/AssertResources.php
+++ b/src/Assert/AssertResources.php
@@ -26,7 +26,7 @@ trait AssertResources
     }
 
 
-    public function assertTotal($amount){
+    public function assertTotalData($amount){
         $total = collect(json_decode(json_encode(Arr::get($this->original, 'total', []), true)));
 
         PHPUnit::assertEquals($amount, (int) $total[0]);

--- a/src/Assert/AssertResources.php
+++ b/src/Assert/AssertResources.php
@@ -24,4 +24,13 @@ trait AssertResources
 
         return $this;
     }
+
+
+    public function assertTotal($amount){
+        $total = collect(json_decode(json_encode(Arr::get($this->original, 'total', []), true)));
+
+        PHPUnit::assertEquals($amount, (int) $total[0]);
+
+        return $this;
+    }
 }

--- a/src/NovaAssertions.php
+++ b/src/NovaAssertions.php
@@ -76,6 +76,14 @@ trait NovaAssertions
         return new NovaResponse($response, compact('endpoint', 'resource'), $this);
     }
 
+    public function novaAction($resource, $action, $data){
+        $resource = $this->resolveUriKey($resource);
+        $endpoint = "/nova-api/$resource/action?action=$action";
+        $response = $this->post($endpoint, $data);
+
+        return new NovaResponse($response, compact('endpoint', 'resource'), $this);
+    }
+
     public function novaUpdate($resource, $data, $resourceId){
         $resource = $this->resolveUriKey($resource);
         $endpoint = "/nova-api/$resource/$resourceId?editMode=update&editing=true";


### PR DESCRIPTION
as create and edit pages read from “fields” not from “resource.fields"

these are the current correct request type -- json route pairs:
index — resources.0.fields
detail — resource.fields
create, edit — fields