### PR TITLE
Hotfix 

### DIFF
--- a/src/Assert/AssertFields.php
+++ b/src/Assert/AssertFields.php
@@ -44,7 +44,7 @@ trait AssertFields
         return $this->fieldCheck($attribute, 'assertJsonMissing', $value);
     }
 
-    protected function fieldCheck($attribute,  $method, $value = null)
+    protected function fieldCheck($attribute, $value, $method = null)
     {
         if ($attribute instanceof Collection) {
             $attribute = $attribute->toArray();

--- a/src/Assert/AssertFields.php
+++ b/src/Assert/AssertFields.php
@@ -36,12 +36,12 @@ trait AssertFields
 
     public function assertFieldsInclude($attribute, $value=null)
     {
-        return $this->fieldCheck($attribute, 'assertJsonFragment', $value);
+        return $this->fieldCheck($attribute, $value, 'assertJsonFragment');
     }
 
     public function assertFieldsExclude($attribute, $value=null)
     {
-        return $this->fieldCheck($attribute, 'assertJsonMissing', $value);
+        return $this->fieldCheck($attribute, $value, 'assertJsonMissing');
     }
 
     protected function fieldCheck($attribute, $value, $method = null)


### PR DESCRIPTION
Fix the following two Issues:  

1)
PHP Fatal error: During class fetch: Uncaught ErrorException: Required parameter $method follows optional parameter $value in /var/www/html/vendor/dillingham/nova-assertions/src/Assert/AssertFields.php:47
Stack trace:
#0 /var/www/html/vendor/composer/ClassLoader.php(444): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError()
#1 /var/www/html/vendor/composer/ClassLoader.php(444): include()
#2 /var/www/html/vendor/composer/ClassLoader.php(322): Composer\Autoload\includeFile()
#3 /var/www/html/vendor/dillingham/nova-assertions/src/NovaResponse.php(17): Composer\Autoload\ClassLoader->loadClass()
#4 /var/www/html/vendor/composer/ClassLoader.php(444): include('...')
#5 /var/www/html/vendor/composer/ClassLoader.php(322): Composer\Autoload\includeFile()
#6 /var/www/html/vendor/dillingham/nova-assertions/src/NovaAssertions.php(18): Composer\Autoload\ClassLoader->loadClass()
#7 /var/www/html/tests/Feature/Nova/BankTest.php(52): Tests\Feature\Nova\BankTest->novaIndex()
#8 /var/www/html/vendor/phpunit/phpunit/src/Framework/TestCase.php(1526): Tests\Feature\Nova\BankTest->itAccessContractListPage()
#9 /var/www/html/vendor/phpunit/phpunit/src/Framework/TestCase.php(1132): PHPUnit\Framework\TestCase->runTest()
#10 /var/www/html/vendor/phpunit/phpunit/src/Framework/TestResult.php(722): PHPUnit\Framework\TestCase->runBare()
#11 /var/www/html/vendor/phpunit/phpunit/src/Framework/TestCase.php(884): PHPUnit\Framework\TestResult->run()
#12 /var/www/html/vendor/phpunit/phpunit/src/Framework/TestSuite.php(677): PHPUnit\Framework\TestCase->run()
#13 /var/www/html/vendor/phpunit/phpunit/src/Framework/TestSuite.php(677): PHPUnit\Framework\TestSuite->run()
#14 /var/www/html/vendor/phpunit/phpunit/src/Framework/TestSuite.php(677): PHPUnit\Framework\TestSuite->run()
#15 /var/www/html/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(667): PHPUnit\Framework\TestSuite->run()
#16 /var/www/html/vendor/phpunit/phpunit/src/TextUI/Command.php(143): PHPUnit\TextUI\TestRunner->run()
#17 /var/www/html/vendor/phpunit/phpunit/src/TextUI/Command.php(96): PHPUnit\TextUI\Command->run()
#18 /var/www/html/vendor/phpunit/phpunit/phpunit(61): PHPUnit\TextUI\Command::main()
#19 {main} in /var/www/html/vendor/dillingham/nova-assertions/src/NovaResponse.php on line 17

-------------------------

2)


  at vendor/laravel/framework/src/Illuminate/Macroable/Traits/Macroable.php:103
     99▕      */
    100▕     public function __call($method, $parameters)
    101▕     {
    102▕         if (! static::hasMacro($method)) {
  ➜ 103▕             throw new BadMethodCallException(sprintf(
    104▕                 'Method %s::%s does not exist.', static::class, $method
    105▕             ));
    106▕         }
    107▕ 

      +4 vendor frames 



